### PR TITLE
Add support for OCaml 5.00

### DIFF
--- a/approx.ml
+++ b/approx.ml
@@ -283,16 +283,16 @@ let approximations s =
   (* Sorting heuristic of approximations with most general ones first *)
   List.fast_sort
     (fun s1 s2 ->
-       let c = Pervasives.compare (Node.dim s1) (Node.dim s2) in
+       let c = Stdlib.compare (Node.dim s1) (Node.dim s2) in
      if c <> 0 then c
      else 
-     let c = Pervasives.compare (Node.size s1) (Node.size s2) in
+     let c = Stdlib.compare (Node.size s1) (Node.size s2) in
        if c <> 0 then c
        else 
-         let c = Pervasives.compare (nb_neq s2) (nb_neq s1) in
+         let c = Stdlib.compare (nb_neq s2) (nb_neq s1) in
          if c <> 0 then c
          else
-           Pervasives.compare (nb_arrays s1) (nb_arrays s2)
+           Stdlib.compare (nb_arrays s1) (nb_arrays s2)
          (* if c <> 0 then c *)
          (* else *)
          (*   SAtom.compare (Node.litterals s1) (Node.litterals s1) *)

--- a/enumerative.ml
+++ b/enumerative.ml
@@ -37,12 +37,12 @@ end)
 
 module SI = Set.Make (struct
     type t = int
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 module SLI = Set.Make (struct
     type t = int list
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 module TMap = Map.Make (Term)
@@ -1181,10 +1181,12 @@ let shuffle d =
     let sond = List.sort compare nd in
     List.rev_map snd sond
 
-let no_scan_states env =
+let no_scan_states _env =
   (* Prevent the GC from scanning the list env.states as it is going to be
      kept in memory all the time. *)
-  List.iter (fun s -> Obj.set_tag (Obj.repr s) (Obj.no_scan_tag)) env.states
+  (* This is commented out for the moment as Obj.set_tag was removed in OCaml 5.00 *)
+  (* List.iter (fun s -> Obj.set_tag (Obj.repr s) (Obj.no_scan_tag)) env.states *)
+  ()
 
 let finalize_search env =
   let st = HST.stats env.explicit_states in
@@ -1443,7 +1445,7 @@ let fast_resist_on_trace ls =
 module SCand =
   Set.Make (struct
       type t = st_req * Atom.t
-      let compare (t,_) (t',_) = Pervasives.compare t t'
+      let compare (t,_) (t',_) = Stdlib.compare t t'
   end)
 
 

--- a/forward.ml
+++ b/forward.ml
@@ -18,7 +18,7 @@ open Options
 open Ast
 open Types
 open Atom
-open Pervasives
+open Stdlib
 
 module H = Hstring
 

--- a/node.ml
+++ b/node.ml
@@ -38,37 +38,37 @@ let compare_kind s1 s2 =
   | Approx, Approx -> 0
   | Approx, _ -> -1
   | _, Approx -> 1
-  | k1, k2 -> Pervasives.compare k1 k2
+  | k1, k2 -> Stdlib.compare k1 k2
 
 let compare_by_breadth s1 s2 =
   let v1 = dim s1 in
   let v2 = dim s2 in
-  let c = Pervasives.compare v1 v2 in
+  let c = Stdlib.compare v1 v2 in
   if c <> 0 then c else
     let c1 = size s1 in
     let c2 = size s2 in
-    let c = Pervasives.compare c1 c2 in
+    let c = Stdlib.compare c1 c2 in
     if c <> 0 then c else
       let c =  compare_kind s1 s2 in
       if c <> 0 then c else
-        let c = Pervasives.compare s1.depth s2.depth in 
+        let c = Stdlib.compare s1.depth s2.depth in
         if c <> 0 then c else
-          Pervasives.compare (abs s1.tag) (abs s2.tag)
+          Stdlib.compare (abs s1.tag) (abs s2.tag)
 
 let compare_by_depth  s1 s2 =
   let v1 = dim s1 in
   let v2 = dim s2 in
-  let c = Pervasives.compare v1 v2 in
+  let c = Stdlib.compare v1 v2 in
   if c <> 0 then c else
     let c1 = size s1 in
     let c2 = size s2 in
-    let c = Pervasives.compare c1 c2 in
+    let c = Stdlib.compare c1 c2 in
     if c <> 0 then c else
       let c =  compare_kind s1 s2 in
       if c <> 0 then c else
-        let c = Pervasives.compare s2.depth s1.depth in 
+        let c = Stdlib.compare s2.depth s1.depth in
         if c <> 0 then c else
-          Pervasives.compare (abs s1.tag) (abs s2.tag)
+          Stdlib.compare (abs s1.tag) (abs s2.tag)
 
 let rec origin n = match n.from with
   | [] -> n

--- a/pretty.ml
+++ b/pretty.ml
@@ -227,14 +227,21 @@ let stop_tag t =
   in
   Printf.sprintf "[%sm" (assoc_style st)
         
+let start_tag = function
+  | Format.String_tag s -> start_tag s
+  | _ -> ""
+
+let stop_tag = function
+  | Format.String_tag s -> stop_tag s
+  | _ -> ""
 
 let add_colors formatter =
   pp_set_tags formatter true;
-  let old_fs = Format.pp_get_formatter_tag_functions formatter () in
-  Format.pp_set_formatter_tag_functions formatter
+  let old_fs = Format.pp_get_formatter_stag_functions formatter () in
+  Format.pp_set_formatter_stag_functions formatter
     { old_fs with
-      Format.mark_open_tag = start_tag;
-      Format.mark_close_tag = stop_tag }
+      Format.mark_open_stag = start_tag;
+      Format.mark_close_stag = stop_tag }
 
 let _ =
   if not nocolor then begin

--- a/smt/alt_ergo.ml
+++ b/smt/alt_ergo.ml
@@ -521,7 +521,7 @@ module Make (Options : sig val profiling : bool end) = struct
     uc
 
   module SInt = 
-    Set.Make (struct type t = int let compare = Pervasives.compare end)
+    Set.Make (struct type t = int let compare = Stdlib.compare end)
 
   let export_unsatcore2 cl =
     let s = 

--- a/smt/combine.ml
+++ b/smt/combine.ml
@@ -61,7 +61,7 @@ struct
     if c = 0 then comparei a b else c
 
   and compare_tag a b = 
-    Pervasives.compare (theory_num a) (theory_num b)
+    Stdlib.compare (theory_num a) (theory_num b)
       
   and comparei a b = 
     match a, b with

--- a/smt/literal.ml
+++ b/smt/literal.ml
@@ -90,7 +90,7 @@ module Make (X : OrderedType) : S with type elt = X.t = struct
 
   module H = Make_consed(V)
 
-  let compare a1 a2 = Pervasives.compare a1.tag a2.tag
+  let compare a1 a2 = Stdlib.compare a1.tag a2.tag
   let equal a1 a2 = a1 == a2
   let hash a1 = a1.tag
 

--- a/smt/symbols.ml
+++ b/smt/symbols.ml
@@ -60,7 +60,7 @@ let compare s1 s2 =  match s1, s2 with
   | Int i1, Int i2 -> Hstring.compare i1 i2
   | Int _, _ -> -1
   | _ ,Int _ -> 1
-  | _  -> Pervasives.compare s1 s2
+  | _  -> Stdlib.compare s1 s2
   
 let equal s1 s2 = compare s1 s2 = 0
 

--- a/smt/term.ml
+++ b/smt/term.ml
@@ -54,7 +54,7 @@ and print_list fmt = function
   | t::l -> Format.fprintf fmt "%a,%a" print t print_list l
 
 let compare t1 t2 =
-  let c = Pervasives.compare t2.tag t1.tag in
+  let c = Stdlib.compare t2.tag t1.tag in
   if c = 0 then c else
   match (view t1).f, (view t2).f with
     | (Sy.True | Sy.False ), (Sy.True | Sy.False ) -> c

--- a/smt/ty.ml
+++ b/smt/ty.ml
@@ -49,7 +49,7 @@ let compare t1 t2 =
     | Tsum (s1, _), Tsum(s2, _) ->
 	Hstring.compare s1 s2
     | Tsum _, _ -> -1 | _ , Tsum _ -> 1
-    | t1, t2 -> Pervasives.compare t1 t2
+    | t1, t2 -> Stdlib.compare t1 t2
 
 let print fmt ty = 
   match ty with

--- a/trace.ml
+++ b/trace.ml
@@ -542,11 +542,11 @@ end
 module Why3 = struct
     
 
-  module CompInt = struct type t = int let compare = Pervasives.compare end
+  module CompInt = struct type t = int let compare = Stdlib.compare end
 
   module NodeH = struct
     type t = Node.t
-    let compare n1 n2 = Pervasives.compare n1.tag n2.tag
+    let compare n1 n2 = Stdlib.compare n1.tag n2.tag
     let equal n1 n2 = n1.tag == n2.tag
     let hash n = n.tag
   end
@@ -1358,11 +1358,11 @@ end
 module Why3_INST = struct
     
 
-  module CompInt = struct type t = int let compare = Pervasives.compare end
+  module CompInt = struct type t = int let compare = Stdlib.compare end
 
   module NodeH = struct
     type t = Node.t
-    let compare n1 n2 = Pervasives.compare n1.tag n2.tag
+    let compare n1 n2 = Stdlib.compare n1.tag n2.tag
     let equal n1 n2 = n1.tag == n2.tag
     let hash n = n.tag
   end
@@ -1370,8 +1370,8 @@ module Why3_INST = struct
   module SPinst = Set.Make (struct
     type t = Node.t * Variable.subst
     let compare (n1, s1) (n2, s2) = 
-      let c = Pervasives.compare n1.tag n2.tag in
-      if c = 0 then Pervasives.compare s1 s2 else c
+      let c = Stdlib.compare n1.tag n2.tag in
+      if c = 0 then Stdlib.compare s1 s2 else c
   end)
 
   module SI = Set.Make(CompInt)

--- a/types.ml
+++ b/types.ml
@@ -64,7 +64,7 @@ module Var = struct
     let compare x y =
       match x, y with
       | V(a1,s1), V(a2, s2) ->
-	 let c = Pervasives.compare s1 s2 in
+	 let c = Stdlib.compare s1 s2 in
 	 if c <> 0 then c
 	 else Hstring.compare a1 a2
 
@@ -97,7 +97,7 @@ let is_int_const = function
      Hstring.equal (snd (Smt.Symbol.type_of n)) Smt.Type.type_int
 
 
-let compare_constants = MConst.compare Pervasives.compare 
+let compare_constants = MConst.compare Stdlib.compare
 
 
 let num_of_const = function
@@ -307,7 +307,7 @@ end = struct
 	  let c1 = Term.compare x1 x2 in
 	  if c1 <> 0  then c1 
 	  else 
-	    let c0 = Pervasives.compare op1 op2 in
+	    let c0 = Stdlib.compare op1 op2 in
 	    if c0 <> 0 then c0 
 	    else 
 	      let c2 = Term.compare y1 y2 in c2
@@ -559,7 +559,7 @@ module ArrayAtom = struct
     !cpt + (n1 - !i1)
 
   let compare_nb_diff a p1 p2 =
-    Pervasives.compare (nb_diff p1 a) (nb_diff p2 a)
+    Stdlib.compare (nb_diff p1 a) (nb_diff p2 a)
 
 
   let nb_common a1 a2 =
@@ -580,7 +580,7 @@ module ArrayAtom = struct
 
 
   let compare_nb_common a p1 p2 =
-    Pervasives.compare (nb_common p2 a) (nb_common p1 a)
+    Stdlib.compare (nb_common p2 a) (nb_common p1 a)
 
   let diff a1 a2 =
     let n1 = Array.length a1 in

--- a/typing.ml
+++ b/typing.ml
@@ -18,7 +18,7 @@ open Util
 open Ast
 open Types
 open Atom
-open Pervasives
+open Stdlib
 
 type error = 
   | UnknownConstr of Hstring.t


### PR DESCRIPTION
Simplified version of #5 for easy review of the significant changes: `Obj.set_tag` is currently used in cubicle and I believe the new API introduced in #5 by @shakthimaan is here to workaround that.

In this PR I’ve simply commented out this part with a comment specifying why as it should be still correct, only just a bit slower (the use of `Obj.set_tag` is only here for performance improvement if I understand correctly)